### PR TITLE
fix: use module level logger instead of root

### DIFF
--- a/python/cuquantum/tensornet/tensor_network.py
+++ b/python/cuquantum/tensornet/tensor_network.py
@@ -228,7 +228,7 @@ class Network:
         cutn_patch = cutn_ver % 100
 
         # Logger.
-        self.logger = options.logger if options.logger is not None else logging.getLogger()
+        self.logger = options.logger if options.logger is not None else logging.getLogger(__name__)
         self.logger.info(f"cuTensorNet version = {cutn_major}.{cutn_minor}.{cutn_patch}")
         self.logger.info("Beginning network creation...")
 


### PR DESCRIPTION
Currently, the logging in the `TensorNetwork` class uses the root logger which pollutes its logs and makes disabling logging from this class difficult. With this PR the logger now uses the module's `__name__` instead of the root logger, which prevents polluting the logs produced by the root logger .