### PR TITLE
fix: replace 17 bare except clauses with except Exception

### DIFF
--- a/benchmarks/nv_quantum_benchmarks/_utils.py
+++ b/benchmarks/nv_quantum_benchmarks/_utils.py
@@ -256,7 +256,7 @@ def get_gpu_driver_version():
         status = func(ctypes.byref(out), 80)
         if status != 0:
             raise RuntimeError('cannot get driver version')
-    except:
+    except Exception:
         ver = "N/A"
     else:
         ver = out.value.decode()

--- a/benchmarks/tests/nv_quantum_benchmarks_tests/test_run.py
+++ b/benchmarks/tests/nv_quantum_benchmarks_tests/test_run.py
@@ -257,7 +257,7 @@ class TestCmdCircuit:
                     assert len(cached_circuits) == 1
                     cached_json = [f for f in glob.glob(str(tmp_path / f"data/{benchmark}.json")) if os.path.isfile(f)]
                     assert len(cached_json) == 1  # TODO: test aggregate behavior too?
-                except:
+                except Exception:
                     # make debugging easier
                     print("stdout:\n", result.stdout.decode())
                     print("stderr:\n", result.stderr.decode())
@@ -314,7 +314,7 @@ class TestCmdApi:
             assert bool(result.check_returncode()) == False
             cached_json = [f for f in glob.glob(str(tmp_path / f"data/{benchmark}.json")) if os.path.isfile(f)]
             assert len(cached_json) == 1  # TODO: test aggregate behavior too?
-        except:
+        except Exception:
             # make debugging easier
             print("stdout:\n", result.stdout.decode())
             print("stderr:\n", result.stderr.decode())
@@ -374,7 +374,7 @@ class TestCmdApi:
             assert bool(result.check_returncode()) == False
             cached_json = [f for f in glob.glob(str(tmp_path / f"data/{benchmark}.json")) if os.path.isfile(f)]
             assert len(cached_json) == 1  # TODO: test aggregate behavior too?
-        except:
+        except Exception:
             # make debugging easier
             print("stdout:\n", result.stdout.decode())
             print("stderr:\n", result.stderr.decode())
@@ -411,7 +411,7 @@ class TestCmdApi:
             assert bool(result.check_returncode()) == False
             cached_json = [f for f in glob.glob(str(tmp_path / f"data/{benchmark}.json")) if os.path.isfile(f)]
             assert len(cached_json) == 1  # TODO: test aggregate behavior too?
-        except:
+        except Exception:
             # make debugging easier
             print("stdout:\n", result.stdout.decode())
             print("stderr:\n", result.stderr.decode())
@@ -465,7 +465,7 @@ class TestCmdApi:
             assert bool(result.check_returncode()) == False
             cached_json = [f for f in glob.glob(str(tmp_path / f"data/{benchmark}.json")) if os.path.isfile(f)]
             assert len(cached_json) == 1  # TODO: test aggregate behavior too?
-        except:
+        except Exception:
             # make debugging easier
             print("stdout:\n", result.stdout.decode())
             print("stderr:\n", result.stderr.decode())

--- a/extra/demo_build_with_wheels/search_package_path.py
+++ b/extra/demo_build_with_wheels/search_package_path.py
@@ -11,7 +11,7 @@ def find_package_location(package_name):
     path = None
     try:
         path = _find_package_location_by_license(package_name)
-    except:
+    except Exception:
         pass
     if path is None:
         path = _find_package_location_by_root(package_name)

--- a/python/builder/utils.py
+++ b/python/builder/utils.py
@@ -46,7 +46,7 @@ def check_cuda_version():
             ver = int(m.group(1))
         else:
             raise RuntimeError("cannot parse CUDA_VERSION")
-    except:
+    except Exception:
         raise
     else:
         # 12020 -> "12.2"

--- a/python/cuquantum/tensornet/tensor_network.py
+++ b/python/cuquantum/tensornet/tensor_network.py
@@ -254,7 +254,7 @@ class Network:
             if ndev == 0:
                 self.cpu_only = True
                 self.device_id = 'cpu'
-        except:
+        except Exception:
             self.cpu_only = True
             self.device_id = 'cpu'
         if not allow_cpu_pathfinder and self.cpu_only:

--- a/python/extensions/setup.py
+++ b/python/extensions/setup.py
@@ -39,7 +39,7 @@ def check_cuda_version():
             ver = int(m.group(1))
         else:
             raise RuntimeError("cannot parse CUDA_VERSION")
-    except:
+    except Exception:
         raise
     else:
         # 12020 -> "12.2"

--- a/python/tests/cuquantum_tests/bindings/__init__.py
+++ b/python/tests/cuquantum_tests/bindings/__init__.py
@@ -268,7 +268,7 @@ class LoggerTestBase:
             try:
                 handle = self.mod.create()
                 self.mod.destroy(handle)
-            except:
+            except Exception:
                 if handle:
                     self.mod.destroy(handle)
                 raise

--- a/python/tests/cuquantum_tests/bindings/test_cupauliprop.py
+++ b/python/tests/cuquantum_tests/bindings/test_cupauliprop.py
@@ -90,7 +90,7 @@ def manage_resource(name):
                     
                 setattr(self, name, h)
                 impl(self, *args, **kwargs)
-            except:
+            except Exception:
                 print(f'managing resource {name} failed')
                 raise
             finally:

--- a/python/tests/cuquantum_tests/bindings/test_cutensornet.py
+++ b/python/tests/cuquantum_tests/bindings/test_cutensornet.py
@@ -24,7 +24,7 @@ try:
     import torch
     # unlike in other test modules, we don't check torch.cuda.is_available()
     # here because we allow verifying against PyTorch CPU tensors
-except:
+except Exception:
     torch = None
 
 from nvmath.internal.utils import check_or_create_options
@@ -161,7 +161,7 @@ def manage_resource(name):
                     assert False, f'name "{name}" not recognized'
                 setattr(self, name, h)
                 impl(self, *args, **kwargs)
-            except:
+            except Exception:
                 print(f'managing resource {name} failed')
                 raise
             finally:

--- a/python/tests/cuquantum_tests/tensornet/utils/approxTN_utils.py
+++ b/python/tests/cuquantum_tests/tensornet/utils/approxTN_utils.py
@@ -561,7 +561,7 @@ def verify_split_SVD(
     shared_extent = array_u.shape[shared_mode_idx]
     try:
         max_mid_extent = min(array_u.size, array_v.size) // shared_extent
-    except:
+    except Exception:
         # for torch
         max_mid_extent = min(array_u.numel(), array_v.numel()) // shared_extent 
     max_extent = split_options.pop('max_extent', max_mid_extent)

--- a/python/tests/cuquantum_tests/tensornet/utils/helpers.py
+++ b/python/tests/cuquantum_tests/tensornet/utils/helpers.py
@@ -70,7 +70,7 @@ def compute_and_normalize_numpy_path(data, num_operands):
     try:
         # this can fail if the TN is too large (ex: containing unicode)
         path, _ = np.einsum_path(*data, optimize=True)
-    except:
+    except Exception:
         raise NotImplementedError
     path = path[1:]
 


### PR DESCRIPTION
## What
Replace 17 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.